### PR TITLE
Fix operators ++ and -- in intrusive_list_iterator

### DIFF
--- a/include/cmsis-plus/utils/lists.h
+++ b/include/cmsis-plus/utils/lists.h
@@ -1081,7 +1081,7 @@ namespace os
       intrusive_list_iterator<T, N, MP, U>::operator++ (int)
       {
         const auto tmp = *this;
-        node_ = static_cast<iterator_pointer> (node_->next);
+        node_ = static_cast<iterator_pointer> (node_->next ());
         return tmp;
       }
 
@@ -1089,7 +1089,7 @@ namespace os
       inline intrusive_list_iterator<T, N, MP, U>&
       intrusive_list_iterator<T, N, MP, U>::operator-- ()
       {
-        node_ = static_cast<iterator_pointer> (node_->prev);
+        node_ = static_cast<iterator_pointer> (node_->prev ());
         return *this;
       }
 
@@ -1098,7 +1098,7 @@ namespace os
       intrusive_list_iterator<T, N, MP, U>::operator-- (int)
       {
         const auto tmp = *this;
-        node_ = static_cast<iterator_pointer> (node_->prev);
+        node_ = static_cast<iterator_pointer> (node_->prev ());
         return tmp;
       }
 


### PR DESCRIPTION
Use of of operator-- and operator++ in intrusive_list_iterator resulted in compilation errors because next and prev were accessed as member elements instead of functions. This patch fixes this issue