### PR TITLE
Fix typos

### DIFF
--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -11,7 +11,7 @@ Using the new C++ definitions, an implementation of CMSIS was added.
 
 To be able to include the C++ definitions, the implementation file
 must be in C++ (`cmsis_os.cpp`), but from the functional point of view,
-it defines the clasical C functions (as `extern "C"`).
+it defines the classical C functions (as `extern "C"`).
 
 ## Add extensions
 

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -23,7 +23,7 @@ From my point of view, the main problems with the CMSIS RTOS API are:
 - no POSIX compliance
 - not C++ friendly.
 
-Please note that I did not ask for C++ APIs, the plain C APIs should be perfectly fine, I just prefered tha APIs to be designed by someone who thinks in C++, not in C (and as such knows how to avoid the usual mess that unstructured C programs bring, especially in the embedded world); unfortunately ARM seems to have no C++ specialists in their design teams.
+Please note that I did not ask for C++ APIs, the plain C APIs should be perfectly fine, I just preferred tha APIs to be designed by someone who thinks in C++, not in C (and as such knows how to avoid the usual mess that unstructured C programs bring, especially in the embedded world); unfortunately ARM seems to have no C++ specialists in their design teams.
 
 ### The CMSIS++ proposal
 
@@ -60,7 +60,7 @@ Avoid mixing time durations (in milliseconds) with timer counts in ticks (#39)
 Add a separate RTC system clock (#40)
 Add os_main() to make the use of a main thread explicit (#41)
 Add support for a synchronised public memory allocator (#42)
-Avoid returning agregates (like osEvent) (#43)
+Avoid returning aggregates (like osEvent) (#43)
 Extend the range for osKernelSysTick() (#44)
 Make the scheme to assign names to objects more consecvent (#46)
 Add missing destructor functions to all objects (#47)
@@ -101,9 +101,9 @@ However, based on the CMSIS++ experience, there are still more design decisions 
 
 ### Final personal thoughts
 
-As a personal remark, the design of the initial CMSIS RTOS API seems greatly influenced by Keil RTX (function names and prototypes), which, in my oppinion, might not necessarily be the most fortunate design, with some ideas from POSIX threads, an established standard.
+As a personal remark, the design of the initial CMSIS RTOS API seems greatly influenced by Keil RTX (function names and prototypes), which, in my opinion, might not necessarily be the most fortunate design, with some ideas from POSIX threads, an established standard.
 
-However the expected influence from POSIX threads is mostly aparent and  inconsecvent.
+However the expected influence from POSIX threads is mostly apparent and  inconsecvent.
 
 In POSIX threads one of the design characteristics is the use of attributes to configure various creation parameters, instead of passing all of them in a long prototype. As such, all functions used to create objects have a pointer to the attributes. For simple use cases, this pointer can be NULL, and reasonable defaults are applied. After this pointer, the function prototypes include a minimum set of mandatory parameters (for example a pointer to the thread function when creating threads).
 
@@ -274,7 +274,7 @@ Suggestion:
 
 * add support for synchronised malloc()/free(); syncronisation can be done either by mutex or scheduler critical sections (assuming no allocations will be performed on interrupts).
 
-### CMSIS RTOS API: Avoid returning agregates (like osEvent) (#43)
+### CMSIS RTOS API: Avoid returning aggregates (like osEvent) (#43)
 
 Although allowed by the C language, and supported by most compilers, returning structures directly is not a good ideea, since it will trigger lots of warnings in build environments where all warnings are enabled.
 
@@ -288,7 +288,7 @@ Suggestion:
 
 The 32-bits value of the returned counter allows only small time ranges.
 
-For example, for a 100 MHz CPU, at 1000 ticks/sec, the SysTick counter divisor is 100.000, or 10^5, allowing only 4*10^(9-5), or 40000 ticks, which represent only 40 seconds beween rollovers.
+For example, for a 100 MHz CPU, at 1000 ticks/sec, the SysTick counter divisor is 100.000, or 10^5, allowing only 4*10^(9-5), or 40000 ticks, which represent only 40 seconds between rollovers.
 
 In [CMSIS++](http://micro-os-plus.github.io/cmsis-plus/), the SysTick clock can return separate values in a user provided  structure, allowing any kind of computations related to accurate timings.
 
@@ -369,9 +369,9 @@ Note: apparently addressed in CMSIS 5, but must be checked.
 
 ### CMSIS RTOS API: Use POSIX error codes (#65)
 
-The CMSIS RTOS API defines a set of error codes, but the semantic is proprietary (and, to my oppinion, not very consistent).
+The CMSIS RTOS API defines a set of error codes, but the semantic is proprietary (and, to my opinion, not very consistent).
 
-Based on POSIX, [CMSIS++](http://micro-os-plus.github.io/cmsis-plus/) uses the standard POSIX error codes from the <errno.h> header file, the only specific definition being `result::ok` to indicate that no error occured.
+Based on POSIX, [CMSIS++](http://micro-os-plus.github.io/cmsis-plus/) uses the standard POSIX error codes from the <errno.h> header file, the only specific definition being `result::ok` to indicate that no error occurred.
 
 Suggestion:
 
@@ -391,7 +391,7 @@ Suggestion:
 
 #### CMSIS RTOS API: For all objects, add reset functions to return the object to initial status (#67)
 
-In [CMSIS++](http://micro-os-plus.github.io/cmsis-plus/) objects can be returned to the inital status with `reset()`.
+In [CMSIS++](http://micro-os-plus.github.io/cmsis-plus/) objects can be returned to the initial status with `reset()`.
 
 Suggestion:
 
@@ -776,7 +776,7 @@ For example, in the compatibility wrapper, the implementation of `osThreadCreate
 
 Suggestion:
 
-* use a consistent, similar loooking, macro to initialise all objects with default values and explictly set structure members for each attribute.
+* use a consistent, similar loooking, macro to initialise all objects with default values and explicitly set structure members for each attribute.
 
 #### CMSIS RTOS API v2: When using attributes, avoid unnecessary creation parameters (#78)
 
@@ -811,7 +811,7 @@ Suggestion:
 
 #### CMSIS RTOS API v2: Fix inconsistent type naming convention (#80)
 
-This is a recuring problem, that seems to affect all CMSIS components, not only RTOS, and, if I remember right, I already reported, but apparently without effect.
+This is a recurring problem, that seems to affect all CMSIS components, not only RTOS, and, if I remember right, I already reported, but apparently without effect.
 
 In the current `cmsis_os.h` I can read the following types:
 
@@ -832,7 +832,7 @@ typedef struct os_mutex_attr {
 
 ```
 
-In my oppinion your general naming convention, not only the type naming convention, is problematic, but the issue here is not which naming convention you choose (this may turn into a religious war), but once you choose it, stick to it consistently.
+In my opinion your general naming convention, not only the type naming convention, is problematic, but the issue here is not which naming convention you choose (this may turn into a religious war), but once you choose it, stick to it consistently.
 
 [CMSIS++](http://micro-os-plus.github.io/cmsis-plus/) uses the lower case naming convention, also adopted by POSIX and by the ISO C/C++ standards, with types suffixed by `_t`. User class names may have the initial character in uppercase.
 

--- a/include/cmsis-plus/posix-io/pool.h
+++ b/include/cmsis-plus/posix-io/pool.h
@@ -90,7 +90,7 @@ namespace os
        */
 
       void*
-      aquire (void);
+      acquire (void);
 
       bool
       release (void* obj);
@@ -196,7 +196,7 @@ namespace os
       public:
 
         value_type*
-        aquire (void);
+        acquire (void);
 
         bool
         release (value_type* obj);
@@ -266,9 +266,9 @@ namespace os
     template<typename T>
       inline typename pool_typed<T>::value_type*
       __attribute__((always_inline))
-      pool_typed<T>::aquire (void)
+      pool_typed<T>::acquire (void)
       {
-        return static_cast<value_type*> (pool::aquire ());
+        return static_cast<value_type*> (pool::acquire ());
       }
 
     template<typename T>

--- a/inspiration/README.md
+++ b/inspiration/README.md
@@ -2,7 +2,7 @@
 
 "Books are written from books, and software is written from software."
 
-As usual for many open source project, this one is also very greatful to other nice people
+As usual for many open source project, this one is also very grateful to other nice people
 who previously contributed their work to the open source community.
 
 For reference, several files from other projects are copied here, to reach them

--- a/inspiration/gcc/libstdc++v3/chrono
+++ b/inspiration/gcc/libstdc++v3/chrono
@@ -691,7 +691,7 @@ _GLIBCXX_END_NAMESPACE_VERSION
     // Clocks. 
 
     // Why nanosecond resolution as the default?  
-    // Why have std::system_clock always count in the higest
+    // Why have std::system_clock always count in the highest
     // resolution (ie nanoseconds), even if on some OSes the low 3
     // or 9 decimal digits will be always zero? This allows later
     // implementations to change the system_clock::now()

--- a/inspiration/gcc/libstdc++v3/future
+++ b/inspiration/gcc/libstdc++v3/future
@@ -428,7 +428,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	    error_code __ec(make_error_code(future_errc::broken_promise));
 	    __res->_M_error = make_exception_ptr(future_error(__ec));
 	    // This function is only called when the last asynchronous result
-	    // provider is abandoning this shared state, so noone can be
+	    // provider is abandoning this shared state, so no one can be
 	    // trying to make the shared state ready at the same time, and
 	    // we can access _M_result directly instead of through call_once.
 	    _M_result.swap(__res);

--- a/src/posix-io/file-system.cpp
+++ b/src/posix-io/file-system.cpp
@@ -320,7 +320,7 @@ namespace os
         }
 
       // Get a file object from the pool.
-      auto* const f = static_cast<file*> (files_pool_->aquire ());
+      auto* const f = static_cast<file*> (files_pool_->acquire ());
 
       // Associate the file with this file system (used, for example,
       // to reach the pools at close).
@@ -342,7 +342,7 @@ namespace os
         }
 
       // Get a directory object from the pool.
-      auto* const dir = static_cast<directory*> (dirs_pool_->aquire ());
+      auto* const dir = static_cast<directory*> (dirs_pool_->acquire ());
 
       // Associate the dir with this file system (used, for example,
       // to reach the pools at close).

--- a/src/posix-io/pool.cpp
+++ b/src/posix-io/pool.cpp
@@ -54,7 +54,7 @@ namespace os
     // ------------------------------------------------------------------------
 
     void*
-    pool::aquire (void)
+    pool::acquire (void)
     {
       for (std::size_t i = 0; i < size_; ++i)
         {

--- a/src/posix-io/socket.cpp
+++ b/src/posix-io/socket.cpp
@@ -48,7 +48,7 @@ namespace os
       errno = 0;
 
       class socket* sock =
-          reinterpret_cast<class socket*> (net_stack::sockets_pool ()->aquire ());
+          reinterpret_cast<class socket*> (net_stack::sockets_pool ()->acquire ());
       if (sock == nullptr)
         {
           errno = ENFILE;
@@ -114,7 +114,7 @@ namespace os
           return nullptr;
         }
 
-      socket* const new_socket = static_cast<socket*> (pool->aquire ());
+      socket* const new_socket = static_cast<socket*> (pool->acquire ());
       if (new_socket == nullptr)
         {
           errno = EMFILE; // pool is considered the per-process table.

--- a/src/rtos/os-core.cpp
+++ b/src/rtos/os-core.cpp
@@ -458,7 +458,7 @@ namespace os
        * @class critical_section
        * @details
        * Use this class to define a critical section
-       * protected to interrupts service routines. The begining of the
+       * protected to interrupts service routines. The beginning of the
        * critical section is exactly the place where this class is
        * instantiated (the constructor will disable interrupts below
        * the scheduler priority). The end of the critical

--- a/test/posix-io/pool/main.cpp
+++ b/test/posix-io/pool/main.cpp
@@ -94,7 +94,7 @@ main (int argc __attribute__((unused)), char* argv[] __attribute__((unused)))
       assert(pool.in_use (i) == false);
     }
 
-  TestFile* fil = pool.aquire ();
+  TestFile* fil = pool.acquire ();
   assert(pool.in_use (0) == true);
   assert(fil == pool.object (0));
 
@@ -108,12 +108,12 @@ main (int argc __attribute__((unused)), char* argv[] __attribute__((unused)))
   // Check full pool.
   for (std::size_t i = 0; i < pool.size (); ++i)
     {
-      fil = pool.aquire ();
+      fil = pool.acquire ();
       assert(fil == pool.object (i));
     }
 
   // One more should return error
-  fil = pool.aquire ();
+  fil = pool.acquire ();
   assert(fil == nullptr);
 
   trace_puts ("'test-pool-debug' succeeded.\n");

--- a/test/rtos/src/test-cpp-api.cpp
+++ b/test/rtos/src/test-cpp-api.cpp
@@ -991,7 +991,7 @@ test_cpp_api (void)
       // Move.
       pass_mutex_up3 (std::move (mx));
 
-      // This pointer is null now, ownership was transfered to function,
+      // This pointer is null now, ownership was transferred to function,
       // which in our case destroyed the object.
       trace::printf ("%p\n", mx.get ());
     }


### PR DESCRIPTION
I've split this into two separate commits for easy reviewing

- Fix an typo in the pool API (aquire -> acquire).
- A mechanical fix-up of some other typos while I was at it.

Obviously the first one is the more useful/important of the two.