### PR TITLE
Added arbitrary power of two alignment for memory allocators

### DIFF
--- a/include/cmsis-plus/memory/first-fit-top.h
+++ b/include/cmsis-plus/memory/first-fit-top.h
@@ -216,14 +216,19 @@ namespace os
       // Offset of payload inside the chunk.
       static constexpr std::size_t chunk_offset = offsetof(chunk_t, next);
       static constexpr std::size_t chunk_align = sizeof(void*);
+      static constexpr std::size_t chunk_minsize = sizeof(chunk_t);
 
-      static constexpr std::size_t block_align = alignof(std::max_align_t);
       static constexpr std::size_t block_minsize = sizeof(void *);
-      static constexpr std::size_t block_maxsize = 1024 * 1024;
-      static constexpr std::size_t block_padding = os::rtos::memory::max (
-          block_align, chunk_align) - chunk_align;
-      static constexpr std::size_t block_minchunk = chunk_offset + block_padding
-          + block_minsize;
+      static constexpr std::size_t
+      calc_block_padding (std::size_t block_align)
+      {
+        return os::rtos::memory::max (block_align, chunk_align) - chunk_align;
+      }
+      static constexpr std::size_t
+      calc_block_minchunk(std::size_t block_padding)
+      {
+        return chunk_offset + block_padding + block_minsize;
+      }
 
       void* arena_addr_ = nullptr;
       // No need for arena_size_bytes_, use total_bytes_.

--- a/src/memory/lifo.cpp
+++ b/src/memory/lifo.cpp
@@ -76,12 +76,12 @@ namespace os
     void*
     lifo::do_allocate (std::size_t bytes, std::size_t alignment)
     {
-      // TODO: consider `alignment` if > block_align.
-
+      std::size_t block_padding = calc_block_padding (alignment);
       std::size_t alloc_size = rtos::memory::align_size (bytes, chunk_align);
       alloc_size += block_padding;
       alloc_size += chunk_offset;
 
+      std::size_t block_minchunk = calc_block_minchunk (block_padding);
       alloc_size = os::rtos::memory::max (alloc_size, block_minchunk);
 
       chunk_t* chunk = nullptr;
@@ -161,12 +161,12 @@ namespace os
       // Compute pointer to payload area.
       char* payload = reinterpret_cast<char *> (chunk) + chunk_offset;
 
-      // Align it to block_align.
+      // Align it to user provided alignment.
       void* aligned_payload = payload;
       std::size_t aligned_size = chunk->size - chunk_offset;
 
       void* res;
-      res = std::align (block_align, bytes, aligned_payload, aligned_size);
+      res = std::align (alignment, bytes, aligned_payload, aligned_size);
       if (res != nullptr)
         {
           assert(res != nullptr);


### PR DESCRIPTION
As per our earlier conversation, here is my suggestion for arbitrary alignment for the allocators. While testing this I found another problem in that if arena size is not evenly divisible with chunk alignment, then on the first allocation the result is actually misaligned. This works on local memory but fails on my peripheral that requires aligned memory access. I added assert for that as well. One more thing that is unresolved here is that functions that deallocate memory also get alignment parameter that is defaulted to `std::max_align_t`. I don't really see a reason for that parameter, but since it is used only for tracing there is no harm done.
