### PR TITLE
messages of message_queue need to be at least the size of a pointer.

### DIFF
--- a/include/cmsis-plus/rtos/os-mqueue.h
+++ b/include/cmsis-plus/rtos/os-mqueue.h
@@ -1767,6 +1767,8 @@ namespace os
           const char* name, const attributes& attr) :
           message_queue (name)
       {
+        static_assert(sizeof(T) >= sizeof(void*), "Messages of message_queue need to have at least the size of a pointer");
+
         internal_construct_ (msgs, sizeof(value_type), attr, &arena_,
                              sizeof(arena_));
       }

--- a/src/rtos/os-mqueue.cpp
+++ b/src/rtos/os-mqueue.cpp
@@ -521,6 +521,10 @@ namespace os
       assert(msg_size_bytes_ == msg_size_bytes);
       assert(msg_size_bytes_ > 0);
 
+      // in order for the list of free messages to not consume additional memory,
+      // the pointers are stored at the beginning of the messages, thus messages should be large enough to fit a pointer
+      assert(msg_size_bytes_ >= sizeof(void*));
+
       msgs_ = static_cast<message_queue::size_t> (msgs);
       assert(msgs_ == msgs);
       assert(msgs > 0);


### PR DESCRIPTION
Check as early as possible for this requirement to not fail with a less specific assert().

This fixes #50 