### PR TITLE
missing noreturn attribute for _exit

### DIFF
--- a/src/libc/stdlib/exit.c
+++ b/src/libc/stdlib/exit.c
@@ -148,7 +148,7 @@ _Exit (int code)
 
 #pragma GCC diagnostic pop
 
-void __attribute__((weak, alias ("_Exit")))
+void __attribute__((weak, alias ("_Exit"), noreturn))
 _exit (int status);
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
fixing to remove compiler warning